### PR TITLE
Bumped image to 8.4.6 and added documentation on official images #88

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,10 @@ RUN rm /app/composer.*
 
 # Stage 2
 # Extend from official PHP image using latest Alpine parent image
-FROM php:8.4.5-cli-alpine
+FROM php:8.4.6-cli-alpine
 
 # Added meta-data about this app
-ARG APP_VERSION="1.2.2"
+ARG APP_VERSION="1.2.3"
 LABEL com.github.aguilita1.app-version=$APP_VERSION  \
       com.github.aguilita1.is-beta="false" \
       com.github.aguilita1.is-production="true" \

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 A reference implementation to demonstrate how to use Github Actions with a simple PHP CLI synchronization application.
 * Published Docker Images: [https://hub.docker.com/r/luigui/samplesyncapp](https://hub.docker.com/r/luigui/samplesyncapp)
 
+## Docker Official Approved Base Images
+* [PHP](https://github.com/docker-library/official-images/blob/master/library/php)
+* [Composer](https://github.com/docker-library/official-images/blob/master/library/composer)
+
 ## Demonstrates Various Continuous Integration Tasks
 * Checkout Code [``actions/checkout@v4``](https://github.com/marketplace/actions/checkout)
 * Validate composer.json and composer.lock  ``run: composer validate --strict``


### PR DESCRIPTION
See #88 
- Patched from php:8.4.5-cli-alpine -> php:8.4.6-cli-alpine.
- Added documentation on how to locate Docker Official Images